### PR TITLE
[explorer/frontend] fix: too long mosaic requests failed with timeout…

### DIFF
--- a/explorer/frontend/__tests__/pages/MosaicInfo.test.js
+++ b/explorer/frontend/__tests__/pages/MosaicInfo.test.js
@@ -57,8 +57,8 @@ describe('MosaicInfo', () => {
 
 			// Assert:
 			expect(fetchMosaicInfo).toHaveBeenCalledWith(params.id);
-			expect(fetchAccountPage).toHaveBeenCalledWith({ mosaic: params.id });
-			expect(fetchTransactionPage).toHaveBeenCalledWith({ mosaic: params.id });
+			expect(fetchAccountPage).not.toHaveBeenCalled();
+			expect(fetchTransactionPage).not.toHaveBeenCalled();
 			expect(result).toEqual(expectedResult);
 		};
 
@@ -68,8 +68,8 @@ describe('MosaicInfo', () => {
 			const expectedResult = {
 				props: {
 					mosaicInfo,
-					preloadedTransactions: transactionPageResult.data,
-					preloadedAccounts: accountPageResult.data
+					preloadedTransactions: [],
+					preloadedAccounts: []
 				}
 			};
 

--- a/explorer/frontend/pages/mosaics/[id].jsx
+++ b/explorer/frontend/pages/mosaics/[id].jsx
@@ -27,8 +27,6 @@ import { useEffect, useState } from 'react';
 
 export const getServerSideProps = async ({ locale, params }) => {
 	const mosaicInfo = await fetchMosaicInfo(params.id);
-	const transactionsPage = await fetchTransactionPage({ mosaic: params.id });
-	const accountsPage = await fetchAccountPage({ mosaic: params.id });
 
 	if (!mosaicInfo) {
 		return {
@@ -39,8 +37,8 @@ export const getServerSideProps = async ({ locale, params }) => {
 	return {
 		props: {
 			mosaicInfo,
-			preloadedTransactions: transactionsPage.data,
-			preloadedAccounts: accountsPage.data,
+			preloadedTransactions: [],
+			preloadedAccounts: [],
 			...(await serverSideTranslations(locale, ['common']))
 		}
 	};
@@ -133,6 +131,8 @@ const MosaicInfo = ({ mosaicInfo, preloadedTransactions, preloadedAccounts }) =>
 			setProgressType(progressType);
 		};
 		fetchChainHeight();
+		accountPagination.initialRequest();
+		transactionPagination.initialRequest();
 	}, [mosaicInfo]);
 
 	return (


### PR DESCRIPTION
… error, add workaround by moving richlist and distribution calls to client side